### PR TITLE
Don't lowercase full config path

### DIFF
--- a/vidcutter/__main__.py
+++ b/vidcutter/__main__.py
@@ -105,14 +105,14 @@ class MainWindow(QMainWindow):
 
     def init_logger(self) -> None:
         try:
-            log_path = QStandardPaths.writableLocation(QStandardPaths.AppConfigLocation).lower()
+            log_path = QStandardPaths.writableLocation(QStandardPaths.AppConfigLocation)
         except AttributeError:
             if sys.platform == 'win32':
                 log_path = os.path.join(QDir.homePath(), 'AppData', 'Local', qApp.applicationName().lower())
             elif sys.platform == 'darwin':
-                log_path = os.path.join(QDir.homePath(), 'Library', 'Preferences', qApp.applicationName()).lower()
+                log_path = os.path.join(QDir.homePath(), 'Library', 'Preferences', qApp.applicationName().lower())
             else:
-                log_path = os.path.join(QDir.homePath(), '.config', qApp.applicationName()).lower()
+                log_path = os.path.join(QDir.homePath(), '.config', qApp.applicationName().lower())
         os.makedirs(log_path, exist_ok=True)
         self.console = ConsoleWidget(self)
         self.consoleLogger = ConsoleHandler(self.console)
@@ -133,15 +133,15 @@ class MainWindow(QMainWindow):
 
     def init_settings(self) -> None:
         try:
-            settings_path = QStandardPaths.writableLocation(QStandardPaths.AppConfigLocation).lower()
+            settings_path = QStandardPaths.writableLocation(QStandardPaths.AppConfigLocation)
         except AttributeError:
             if sys.platform == 'win32':
                 settings_path = os.path.join(QDir.homePath(), 'AppData', 'Local', qApp.applicationName().lower())
             elif sys.platform == 'darwin':
                 settings_path = os.path.join(QDir.homePath(), 'Library', 'Preferences',
-                                             qApp.applicationName()).lower()
+                                             qApp.applicationName().lower())
             else:
-                settings_path = os.path.join(QDir.homePath(), '.config', qApp.applicationName()).lower()
+                settings_path = os.path.join(QDir.homePath(), '.config', qApp.applicationName().lower())
         os.makedirs(settings_path, exist_ok=True)
         settings_file = '%s.ini' % qApp.applicationName().lower()
         self.settings = QSettings(os.path.join(settings_path, settings_file), QSettings.IniFormat)


### PR DESCRIPTION
Make sure all paths constructed for log/settings files have their case preserved, for users whose $HOME is mixed-case. Fixes #64 .

This is a breaking change, as it means that on Linux and macOS when `QStandardPaths.writableLocation(QStandardPaths.AppConfigLocation)` is used (as it normally should be), the user's config dir will change from e.g. (for Linux) `$HOME/.config/vidcutter/` to `$HOME/.config/VidCutter/`, and settings will need to be manually migrated. But there's really no helping that, as lowercasing the entire path is _not_ a workable option. (Also, formerly on macOS if the `QStandardPaths` path was not used, the workaround generated would've been lowercased to `$HOME/library/preferences/vidcutter/` which is very wrong.)

