### PR TITLE
Correct command-line usage summary

### DIFF
--- a/vidcutter/__main__.py
+++ b/vidcutter/__main__.py
@@ -175,8 +175,8 @@ class MainWindow(QMainWindow):
     def parse_cmdline(self) -> None:
         self.parser = QCommandLineParser()
         self.parser.setApplicationDescription('\nVidCutter - the simplest + fastest media cutter & joiner')
-        self.parser.addPositionalArgument('video', 'Preload video file', '[video]')
-        self.parser.addPositionalArgument('project', 'Open VidCutter project file (.vcp)', '[project]')
+        self.parser.addPositionalArgument('video', 'Preload video file', '[video |')
+        self.parser.addPositionalArgument('project', 'Open VidCutter project file (.vcp)', 'project]')
         self.debug_option = QCommandLineOption(['debug'], 'debug mode; verbose console output & logging. '
                                                'This will basically output what is being logged to file to the '
                                                'console stdout. Mainly useful for debugging problems with your '


### PR DESCRIPTION
This change will update the usage string for `vidcutter --help` from:

    Usage: /usr/bin/vidcutter [options] [video] [project]

to

    Usage: /usr/bin/vidcutter [options] [video | project]

which is more representative of the actual parsing, since VidCutter expects only one positional argument, and will ignore any additional.

Getting the correct formatting required "abusing" `addPositionalArgument()` _slightly_, since by default it isn't really equipped to handle mutually-exclusive positional arguments.