### PR TITLE
Always write chapter string to .vcp

### DIFF
--- a/vidcutter/videocutter.py
+++ b/vidcutter/videocutter.py
@@ -953,7 +953,7 @@ class VideoCutter(QWidget):
                     if self.createChapters:
                         chapter = '"{}"'.format(clip[4]) if clip[4] is not None else '""'
                     else:
-                        chapter = ''
+                        chapter = '""'
                     # noinspection PyUnresolvedReferences
                     QTextStream(file) << '{0}\t{1}\t{2}\t{3}\n'.format(self.delta2String(start_time),
                                                                        self.delta2String(stop_time), 0, chapter)


### PR DESCRIPTION
When "Create chapters per clip" is switched off, VidCutter writes `.vcp` files with chapter lines containing _no_ fourth value, which it is then unable to read (reporting "Invalid line" for every line in the file after the first). 

This change causes the fourth value of the project file's chapter lines to always be written as `""` whenever the create-chapters preference is turned off, ensuring that the resulting `.vcp` file can be read by VidCutter.