### PR TITLE
Update videoservice.py

### DIFF
--- a/vidcutter/libs/videoservice.py
+++ b/vidcutter/libs/videoservice.py
@@ -91,7 +91,8 @@ class VideoService(QObject):
                     self.logger.info(self.media)
                 for codec_type in Streams.__members__:
                     setattr(self.streams, codec_type.lower(),
-                            [stream for stream in self.media.streams if stream.codec_type == codec_type.lower()])
+                            [stream for stream in self.media.streams
+                             if hasattr(stream, 'codec_type') and stream.codec_type == codec_type.lower()])
                 if len(self.streams.video):
                     self.streams.video = self.streams.video[0]  # we always assume one video stream per media file
                 else:


### PR DESCRIPTION
Avoid getting an AttributeError since not all streams have a codec_type. Example:
        {
            "index": 6,
            "codec_tag_string": "[12][0][0][0]",
            "codec_tag": "0x000c",
            "id": "0x9d6",
            "r_frame_rate": "0/0",
            "avg_frame_rate": "0/0",
            "time_base": "1/90000",
            "start_pts": 3140393713,
            "start_time": "34893.263478",
            "duration_ts": 1703467413,
            "duration": "18927.415700",
            "disposition": {
                "default": 0,
                "dub": 0,
                "original": 0,
                "comment": 0,
                "lyrics": 0,
                "karaoke": 0,
                "forced": 0,
                "hearing_impaired": 0,
                "visual_impaired": 0,
                "clean_effects": 0,
                "attached_pic": 0,
                "timed_thumbnails": 0
            }
        },