### PR TITLE
Add some defensive-coding checks

### DIFF
--- a/vidcutter/libs/videoservice.py
+++ b/vidcutter/libs/videoservice.py
@@ -577,7 +577,10 @@ class VideoService(QObject):
                     keyframe_times.append(timecode[:-3])
                 else:
                     keyframe_times.append(float(timecode))
-        last_keyframe = self.duration().toString('h:mm:ss.zzz')
+        if formatted_time:
+            last_keyframe = self.duration().toString('h:mm:ss.zzz')
+        else:
+            last_keyframe = float(self.duration().msecsSinceStartOfDay() / 1000.0)
         if keyframe_times[-1] != last_keyframe:
             keyframe_times.append(last_keyframe)
         if source == self.source and not formatted_time:

--- a/vidcutter/libs/videoservice.py
+++ b/vidcutter/libs/videoservice.py
@@ -570,6 +570,7 @@ class VideoService(QObject):
         result = self.cmdExec(self.backends.ffprobe, args, output=True, suppresslog=True, mergechannels=False)
         keyframe_times = []
         for line in result.split('\n'):
+            if ',' not in line: continue
             if line.split(',')[1] != 'N/A':
                 timecode = line.split(',')[1]
             if re.search(',K', line):

--- a/vidcutter/libs/videoservice.py
+++ b/vidcutter/libs/videoservice.py
@@ -451,7 +451,7 @@ class VideoService(QObject):
     def cleanup(files: List[str]) -> None:
         try:
             [os.remove(file) for file in files]
-        except FileNotFoundError:
+        except (FileNotFoundError, TypeError):
             pass
 
     def join(self, inputs: List[str], output: str, allstreams: bool=True, chapters: Optional[List[str]]=None) -> bool:
@@ -622,6 +622,7 @@ class VideoService(QObject):
             video_bsf, audio_bsf = self.getBSF(inputs[0])
             # 1. transcode to mpeg transport streams
             for file in inputs:
+                if not file: continue
                 name, _ = os.path.splitext(file)
                 outfile = '{}.ts'.format(name)
                 outfiles.append(outfile)


### PR DESCRIPTION
These changes deal with a variety of traceback exposures under certain circumstances that, in practice, occur fairly often:

* Empty strings / `None` values on the `inputs` file path list
* Not properly respecting `formatted_time` during the `last_keyframe` adjustment
* Blank/short lines in the `ffprobe` CSV output that don't match the regexp used to parse them
