### PR TITLE
Updated README to remove deprecated syntax for HomeBrew (macos)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Native installers for Windows and macOS are available on the releases page with 
 For macOS users of Homebrew, VidCutter can be easily installed as a "cask". With Homebrew already installed, just run the following terminal command:
 
 ```
-$ brew cask install vidcutter
+$ brew install vidcutter
 ```
 
 #### Chocolatey package


### PR DESCRIPTION
Since brew v2.6.0 `brew cask ...` commands are deprecated.

See https://brew.sh/2020/12/01/homebrew-2.6.0/