### PR TITLE
Fix reading and writing of project files

### DIFF
--- a/vidcutter/__main__.py
+++ b/vidcutter/__main__.py
@@ -175,8 +175,7 @@ class MainWindow(QMainWindow):
     def parse_cmdline(self) -> None:
         self.parser = QCommandLineParser()
         self.parser.setApplicationDescription('\nVidCutter - the simplest + fastest media cutter & joiner')
-        self.parser.addPositionalArgument('video', 'Preload video file', '[video]')
-        self.parser.addPositionalArgument('project', 'Open VidCutter project file (.vcp)', '[project]')
+        self.parser.addPositionalArgument('filename', 'Load video or project file (.edl, .vcp) on startup', '[filename]')
         self.debug_option = QCommandLineOption(['debug'], 'debug mode; verbose console output & logging. '
                                                'This will basically output what is being logged to file to the '
                                                'console stdout. Mainly useful for debugging problems with your '

--- a/vidcutter/__main__.py
+++ b/vidcutter/__main__.py
@@ -94,7 +94,7 @@ class MainWindow(QMainWindow):
     @pyqtSlot(str)
     def file_opener(self, filename: str) -> None:
         try:
-            if QFileInfo(filename).suffix() == 'vcp':
+            if QFileInfo(filename).suffix() in ['edl', 'vcp']:
                 self.cutter.openProject(project_file=filename)
                 if filename == os.path.join(QDir.tempPath(), MainWindow.TEMP_PROJECT_FILE):
                     os.remove(os.path.join(QDir.tempPath(), MainWindow.TEMP_PROJECT_FILE))

--- a/vidcutter/videocutter.py
+++ b/vidcutter/videocutter.py
@@ -125,7 +125,9 @@ class VideoCutter(QWidget):
         self.videoService.addScenes.connect(self.addScenes)
 
         self.project_files = {
-            'edl': re.compile(r'(\d+(?:\.?\d+)?)\t(\d+(?:\.?\d+)?)\t([01])'),
+            # Should return 4 match groups: clip start timestamp, end timestamp, [unused], chapter name
+            # EDL does not have chapter names -> add an empty match group in their place
+            'edl': re.compile(r'(\d+(?:\.?\d+)?)\t(\d+(?:\.?\d+)?)\t([01])()'),
             'vcp': re.compile(r'(\d+(?:\.?\d+)?)\t(\d+(?:\.?\d+)?)\t([01])\t(".*")$')
         }
 

--- a/vidcutter/videocutter.py
+++ b/vidcutter/videocutter.py
@@ -883,6 +883,7 @@ class VideoCutter(QWidget):
             self.blackdetectAction.setEnabled(True)
             self.inCut = False
             self.newproject = True
+            self.renderClipIndex()
             QTimer.singleShot(2000, self.selectClip)
             qApp.restoreOverrideCursor()
             if project_file != os.path.join(QDir.tempPath(), self.parent.TEMP_PROJECT_FILE):

--- a/vidcutter/videocutter.py
+++ b/vidcutter/videocutter.py
@@ -926,9 +926,9 @@ class VideoCutter(QWidget):
         project_file, _ = os.path.splitext(self.currentMedia)
         if reboot:
             project_save = os.path.join(QDir.tempPath(), self.parent.TEMP_PROJECT_FILE)
-            ptype = 'VidCutter Project (*.vcp)'
+            project_type = 'vcp'
         else:
-            project_save, ptype = QFileDialog.getSaveFileName(
+            project_save, _ = QFileDialog.getSaveFileName(
                 parent=self.parent,
                 caption='Save project',
                 directory='{}.vcp'.format(project_file),
@@ -937,12 +937,14 @@ class VideoCutter(QWidget):
                 options=self.getFileDialogOptions())
         if project_save is not None and len(project_save.strip()):
             file = QFile(project_save)
+            info = QFileInfo(file)
+            project_type = info.suffix()
             if not file.open(QFile.WriteOnly | QFile.Text):
                 QMessageBox.critical(self.parent, 'Cannot save project',
                                      'Cannot save project file at {0}:\n\n{1}'.format(project_save, file.errorString()))
                 return
             qApp.setOverrideCursor(Qt.WaitCursor)
-            if ptype == 'VidCutter Project (*.vcp)':
+            if project_type == 'vcp':
                 # noinspection PyUnresolvedReferences
                 QTextStream(file) << '{}\n'.format(self.currentMedia)
             for clip in self.clipTimes:
@@ -950,7 +952,7 @@ class VideoCutter(QWidget):
                                        milliseconds=clip[0].msec())
                 stop_time = timedelta(hours=clip[1].hour(), minutes=clip[1].minute(), seconds=clip[1].second(),
                                       milliseconds=clip[1].msec())
-                if ptype == 'VidCutter Project (*.vcp)':
+                if project_type == 'vcp':
                     if self.createChapters and clip[4] is not None:
                         chapter = clip[4]
                     else:

--- a/vidcutter/videocutter.py
+++ b/vidcutter/videocutter.py
@@ -951,12 +951,12 @@ class VideoCutter(QWidget):
                 stop_time = timedelta(hours=clip[1].hour(), minutes=clip[1].minute(), seconds=clip[1].second(),
                                       milliseconds=clip[1].msec())
                 if ptype == 'VidCutter Project (*.vcp)':
-                    if self.createChapters:
-                        chapter = '"{}"'.format(clip[4]) if clip[4] is not None else '""'
+                    if self.createChapters and clip[4] is not None:
+                        chapter = clip[4]
                     else:
                         chapter = ''
                     # noinspection PyUnresolvedReferences
-                    QTextStream(file) << '{0}\t{1}\t{2}\t{3}\n'.format(self.delta2String(start_time),
+                    QTextStream(file) << '{0}\t{1}\t{2}\t"{3}"\n'.format(self.delta2String(start_time),
                                                                        self.delta2String(stop_time), 0, chapter)
                 else:
                     # noinspection PyUnresolvedReferences

--- a/vidcutter/videocutter.py
+++ b/vidcutter/videocutter.py
@@ -941,6 +941,10 @@ class VideoCutter(QWidget):
             file = QFile(project_save)
             info = QFileInfo(file)
             project_type = info.suffix()
+            if project_type not in ['vcp', 'edl']:
+                QMessageBox.critical(self.parent, 'Cannot save project',
+                                     'Invalid project file extension "{0}".\nOnly .edl and .vcp are supported.'.format(project_type))
+                return
             if not file.open(QFile.WriteOnly | QFile.Text):
                 QMessageBox.critical(self.parent, 'Cannot save project',
                                      'Cannot save project file at {0}:\n\n{1}'.format(project_save, file.errorString()))


### PR DESCRIPTION
This PR addresses multiple problems with project files (see #272 and in particular https://github.com/ozmartian/vidcutter/issues/272#issuecomment-1031884298):

- Make it possible (again?) to write VCP files (was broken by a string comparison that could never succeed)
- Fix VCP format output when no chapter names are set
- Fix EDL format input (doesn't contain chapter names, which broke the parser)
- Support both EDL and VCP files when drag-and-dropped onto the program window
- Refresh clip list after loading a project file (otherwise the newly loaded clips won't be visible)

One feature goes a bit beyond bugfixing, but should probably be useful:
- Modify project file reader to support EDL and VCP at the same time (so the .edl/.vcp file extension doesn't matter anymore)  
  This also allows reading the "broken" project files produced by VidCutter so far: They had a .vcp extension, but contained EDL data. The new parser regex handles this gracefully.